### PR TITLE
Add REST method to resolve exec params

### DIFF
--- a/api/model/model_types.go
+++ b/api/model/model_types.go
@@ -38,11 +38,18 @@ type ContainerInfo struct {
 	PodName       string
 }
 
+//ResolvedExec holds info client might send to create exec
+type ResolvedExec struct {
+	PodName       string   `json:"pod"`
+	ContainerName string   `json:"container"`
+	Cmd           []string `json:"cmd"`
+}
+
 // Todo code Refactoring: MachineExec should be simple object for exec creation, without any business logic
 type MachineExec struct {
 	Identifier MachineIdentifier `json:"identifier"`
 	Cmd        []string          `json:"cmd"`
-	// Supported values for now 'shell', "", "process". If type is empty "", than type will resolved like "shell".
+	// Supported values for now 'shell', "", "process". If type is empty "", then type will resolved like "shell".
 	Type string `json:"type"`
 
 	Tty  bool   `json:"tty"`

--- a/exec/exec-manager-provider.go
+++ b/exec/exec-manager-provider.go
@@ -25,6 +25,10 @@ var execManager ExecManager
 
 // ExecManager to manage exec life cycle.
 type ExecManager interface {
+	// Resolve resolves exec info
+	// the first container with available shell will be picked up if omit
+	Resolve(container, token string) (*model.ResolvedExec, error)
+
 	// Create new Exec defined by machine exec model object.
 	Create(machineExec *model.MachineExec) (int, error)
 

--- a/exec/kubernetes_exec_manager.go
+++ b/exec/kubernetes_exec_manager.go
@@ -67,6 +67,84 @@ func NewK8sExecManager(
 	}
 }
 
+func (manager *KubernetesExecManager) Resolve(container, token string) (*model.ResolvedExec, error) {
+	machineExec := &model.MachineExec{
+		BearerToken: token,
+	}
+	k8sAPI, err := manager.k8sAPIProvider.GetK8sAPI(machineExec)
+	if err != nil {
+		logrus.Debugf("Unable to get k8sAPI %s", err.Error())
+		return nil, err
+	}
+	logrus.Debug("Successfully Got k8sApi object.")
+
+	if container != "" {
+		containerFilter := filter.NewKubernetesContainerFilter(manager.namespace, k8sAPI.GetClient().CoreV1())
+		containerInfo, err := containerFilter.GetContainer(container)
+		if err != nil {
+			return nil, err
+		}
+		cmdResolver := NewCmdResolver(k8sAPI, manager.namespace)
+		resolvedCmd, err := cmdResolver.ResolveCmd(*machineExec, containerInfo)
+
+		if err != nil {
+			return nil, err
+		}
+
+		logrus.Printf("%s is successfully resolved in auto discovered container %s/%s", resolvedCmd,
+			containerInfo.PodName, containerInfo.ContainerName)
+		return &model.ResolvedExec{
+			PodName:       containerInfo.PodName,
+			ContainerName: containerInfo.ContainerName,
+			Cmd:           resolvedCmd,
+		}, nil
+	} else {
+		return manager.findFirstAvailable(k8sAPI, machineExec)
+	}
+}
+
+//TODO Try to refactor it in the way to be able to reuse it in manager.Create
+func (manager *KubernetesExecManager) findFirstAvailable(k8sAPI *client.K8sAPI, machineExec *model.MachineExec) (*model.ResolvedExec, error) {
+	containerFilter := filter.NewKubernetesContainerFilter(manager.namespace, k8sAPI.GetClient().CoreV1())
+	// connect to the first available container. Workaround for Cloud Shell https://github.com/eclipse/che/issues/15434
+	containersInfo, err := containerFilter.GetContainerList()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containersInfo) == 0 {
+		return nil, errors.New("no containers found to exec")
+	}
+
+	errs := make(map[string]error)
+	for _, containerInfo := range containersInfo {
+		cmdResolver := NewCmdResolver(k8sAPI, manager.namespace)
+		resolvedCmd, err := cmdResolver.ResolveCmd(*machineExec, containerInfo)
+		if err != nil {
+			errs[containerInfo.ContainerName] = err
+			continue
+		}
+
+		logrus.Printf("%s is successfully resolved in auto discovered container %s/%s", resolvedCmd,
+			containerInfo.PodName, containerInfo.ContainerName)
+		return &model.ResolvedExec{
+			PodName:       containerInfo.PodName,
+			ContainerName: containerInfo.ContainerName,
+			Cmd:           resolvedCmd,
+		}, nil
+	}
+
+	var containers []string
+	for _, c := range containersInfo {
+		containers = append(containers, c.PodName+"\\"+c.ContainerName)
+	}
+	var buf strings.Builder
+	for container, err := range errs {
+		buf.WriteString(fmt.Sprintf("- %s: %s\n", container, err.Error()))
+	}
+	return nil, fmt.Errorf("failed to resolve exec in any of {%s} -- errors: \n%s", strings.Join(containers, ", "), buf.String())
+}
+
 // Create new exec request object
 func (manager *KubernetesExecManager) Create(machineExec *model.MachineExec) (int, error) {
 	k8sAPI, err := manager.k8sAPIProvider.GetK8sAPI(machineExec)

--- a/filter/kubernetes_filter.go
+++ b/filter/kubernetes_filter.go
@@ -14,6 +14,7 @@ package filter
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/eclipse/che-machine-exec/api/model"
@@ -64,6 +65,23 @@ func (filter *KubernetesContainerFilter) GetContainerList() (containersInfo []*m
 	}
 
 	return containersInfo, nil
+}
+
+func (filter *KubernetesContainerFilter) GetContainer(name string) (containerInfo *model.ContainerInfo, err error) {
+	pods, err := filter.getWorkspacePods()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == name {
+				return &model.ContainerInfo{ContainerName: container.Name, PodName: pod.Name}, nil
+			}
+		}
+	}
+
+	return nil, errors.New(fmt.Sprintf("Workspace-related pod does not have container with name %s", name))
 }
 
 // Find container information by pod label: "wsId" and container environment variables "machineName".

--- a/main.go
+++ b/main.go
@@ -13,8 +13,6 @@
 package main
 
 import (
-	"net/http"
-
 	jsonrpc "github.com/eclipse/che-go-jsonrpc"
 	"github.com/eclipse/che-go-jsonrpc/jsonrpcws"
 	"github.com/eclipse/che-machine-exec/api/events"
@@ -26,6 +24,7 @@ import (
 	"github.com/eclipse/che-machine-exec/cfg"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"net/http"
 )
 
 func main() {
@@ -41,13 +40,12 @@ func main() {
 		})
 	}
 
-	// connect to exec api end point(websocket with json-rpc)
+	// connect to exec api endpoint(websocket with json-rpc)
 	r.GET("/connect", func(c *gin.Context) {
 		var token string
 
 		if cfg.UseBearerToken {
 			token = c.Request.Header.Get(model.BearerTokenHeader)
-
 		}
 
 		conn, err := jsonrpcws.Upgrade(c.Writer, c.Request)
@@ -56,7 +54,7 @@ func main() {
 			return
 		}
 
-		logrus.Debug("Create json-rpc channel for new websocket connnection")
+		logrus.Debug("Create json-rpc channel for new websocket connection")
 		tunnel := jsonrpc.NewManagedTunnel(conn)
 		if len(token) > 0 {
 			tunnel.Attributes[execRpc.BearerTokenAttr] = token
@@ -78,6 +76,10 @@ func main() {
 
 	r.POST("/exec/config", func(c *gin.Context) {
 		rest.HandleKubeConfig(c)
+	})
+
+	r.GET("/exec/resolve", func(c *gin.Context) {
+		rest.HandleResolve(c)
 	})
 
 	// create json-rpc routs group


### PR DESCRIPTION
This PR adds REST method to resolve exec params (default shell, pod and container name).
It allows reusing the existing OpenShift Terminal UI element and doesn't port cloud-shell frontend to OpenShift Console at this stage. It can be revised later.

The PR's base will be changed as soon as Josh merges his PR.

I've left a couple of TODOs and going to review it by myself before making ready to review but feel free to left early feedbacks or proposals.

It's implemented to be used by OpenShift Console Proxy https://github.com/sleshchenko/console/tree/proxiedTerminal
Note that frontend changes are not pushed there yet